### PR TITLE
[NEW]: Implement `opentelekomcloud_config` for `rancher2_machine_config_v2`

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -315,7 +315,7 @@ The following attributes are exported:
 * `ip_version` - (Optional) OpenTelekomCloud version of IP address assigned for the machine. Default `4` (string)
 * `keypair_name` - (Optional) OpenTelekomCloud keypair to use to SSH to the instance (string)
 * `password` - (Optional/Sensitive) OpenTelekomCloud password  (string)
-* `private_key_file` - (Optional/Sensitive) Private key content to use for SSH (string)
+* `private_key_file` - (Optional) Private key content to use for SSH (string)
 * `project_id` - (Required+) OpenTelekomCloud project id. Conflicts with `project_name` (string)
 * `project_name` - (Required+) OpenTelekomCloud project name. Conflicts with `project_id` (string)
 * `region` - (Required) OpenTelekomCloud region name (string)
@@ -331,13 +331,13 @@ The following attributes are exported:
 * `subnet_id` - (Required++) OpenTelekomCloud subnet ID of the machine. Conflicts with `subnet_name` (string)
 * `subnet_name` - (Required++) OpenTelekomCloud subnet name of the machine. Conflicts with `subnet_id` (string)
 * `token` - (Optional/Sensitive) OpenTelekomCloud authentication token (string)
-* `tags` - (Optional/Sensitive) OpenTelekomCloud tags (e.g. key1,value1,key2,value2) (string)
+* `tags` - (Optional) OpenTelekomCloud tags (e.g. key1,value1,key2,value2) (string)
 * `user_data_file` - (Optional) File containing an OpenTelekomCloud userdata script (string)
 * `user_data_raw` - (Optional) Contents of the OpenTelekomCloud userdata as a string (string)
 * `username` - (Optional) OpenTelekomCloud username (string)
 * `vpc_id` - (Required+) OpenTelekomCloud virtual private cloud id. Conflicts with `vpc_name` (string)
 * `vpc_name` - (Required+) OpenTelekomCloud virtual private cloud name. Conflicts with `vpc_id` (string)
-> **Note:**: `Required+` denotes that either the _name or _id is required but you cannot use both.
+> **Note:**: `Required+` denotes that either the _name or _id is required, but you cannot use both.
 
 ### `vsphere_config`
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -6,7 +6,7 @@ page_title: "rancher2_machine_config_v2 Resource"
 
 Provides a Rancher v2 Machine config v2 resource. This can be used to create Machine Config v2 for Rancher v2 and retrieve their information. This resource is available from Rancher v2.6.0 and above.
 
-The supported cloud providers includes `amazonec2`, `azure`, `digitalocean`, `harvester`, `linode`, `openstack`, and `vsphere`.
+The supported cloud providers includes `amazonec2`, `azure`, `digitalocean`, `harvester`, `linode`, `openstack`, `opentelekomcloud` and `vsphere`.
 
 ## Example Usage
 
@@ -291,6 +291,53 @@ The following attributes are exported:
 > **Note:**: `Required+` denotes that either the _name or _id is required but you cannot use both.
 > **Note:**: `Required++` denotes that either the _name or _id is required unless `application_credential_id` is defined.
 > **Note for OpenStack users:**: `keypair_name` is required to be in the schema even if there are no references in rancher itself
+
+### `opentelekomcloud_config`
+
+#### Arguments
+
+* `auth_url` - (Required) OpenTelekomCloud authentication URL (string)
+* `access_key` - (Optional/Sensitive) OpenTelekomCloud access key (string)
+* `secret_key` - (Optional/Sensitive) OpenTelekomCloud secret key (string)
+* `availability_zone` - (Required) OpenTelekomCloud availability zone (string)
+* `ca_cert` - (Optional) CA certificate bundle to verify against (string)
+* `domain_id` - (Required+) OpenTelekomCloud domain ID. Conflicts with `domain_name` (string)
+* `domain_name` - (Required+) OpenTelekomCloud domain name. Conflicts with `domain_id` (string)
+* `eip` - (Optional) OpenTelekomCloud elastic ip address (string)
+* `eip_type` - (Optional) OpenTelekomCloud elastic ip type. Default `5_bgp` (string)
+* `endpoint_type` - (Optional) OpenTelekomCloud endpoint type. Default `public` (string)
+* `flavor_id` - (Optional) OpenTelekomCloud flavor id to use for the instance (string)
+* `flavor_name` - (Optional) OpenTelekomCloud flavor name to use for the instance. Default `s3.xlarge.2` (string)
+* `bandwidth_size` - (Optional) OpenTelekomCloud elastic IP bandwidth size. Default `100` (string)
+* `bandwidth_type` - (Optional) OpenTelekomCloud elastic IP bandwidth type. Default `PER` (string)
+* `image_id` - (Required+) OpenTelekomCloud image id to use for the instance (string)
+* `image_name` - (Required+) OpenTelekomCloud image name to use for the instance (string)
+* `ip_version` - (Optional) OpenTelekomCloud version of IP address assigned for the machine. Default `4` (string)
+* `keypair_name` - (Optional) OpenTelekomCloud keypair to use to SSH to the instance (string)
+* `password` - (Optional/Sensitive) OpenTelekomCloud password  (string)
+* `private_key_file` - (Optional/Sensitive) Private key content to use for SSH (string)
+* `project_id` - (Required+) OpenTelekomCloud project id. Conflicts with `project_name` (string)
+* `project_name` - (Required+) OpenTelekomCloud project name. Conflicts with `project_id` (string)
+* `region` - (Required) OpenTelekomCloud region name (string)
+* `root_volume_size` - (Optional) OpenTelekomCloud volume size (GiB). Default `40` (string)
+* `root_volume_type` - (Optional) OpenTelekomCloud volume type. Default `SSD` (string)
+* `security_groups` - (Optional) OpenTelekomCloud list of security groups for the machine (list)
+* `server_group` - (Optional) OpenTelekomCloud server group where server will be created (string)
+* `server_group_id` - (Optional) OpenTelekomCloud server group id where server will be created (string)
+* `skip_default_sg` - (Optional) Parameter to skip default security group creation (bool)
+* `skip_eip` - (Optional) Parameter to skip eip creation and set machine IP to instance local IP (bool)
+* `ssh_port` - (Optional) OpenTelekomCloud SSH port * Default `22` (string)
+* `ssh_user` - (Optional) OpenTelekomCloud SSH user * Default: `ubuntu` (string)
+* `subnet_id` - (Required++) OpenTelekomCloud subnet ID of the machine. Conflicts with `subnet_name` (string)
+* `subnet_name` - (Required++) OpenTelekomCloud subnet name of the machine. Conflicts with `subnet_id` (string)
+* `token` - (Optional/Sensitive) OpenTelekomCloud authentication token (string)
+* `tags` - (Optional/Sensitive) OpenTelekomCloud tags (e.g. key1,value1,key2,value2) (string)
+* `user_data_file` - (Optional) File containing an OpenTelekomCloud userdata script (string)
+* `user_data_raw` - (Optional) Contents of the OpenTelekomCloud userdata as a string (string)
+* `username` - (Optional) OpenTelekomCloud username (string)
+* `vpc_id` - (Required+) OpenTelekomCloud virtual private cloud id. Conflicts with `vpc_name` (string)
+* `vpc_name` - (Required+) OpenTelekomCloud virtual private cloud name. Conflicts with `vpc_id` (string)
+> **Note:**: `Required+` denotes that either the _name or _id is required but you cannot use both.
 
 ### `vsphere_config`
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -331,7 +331,7 @@ The following attributes are exported:
 * `subnet_id` - (Required++) OpenTelekomCloud subnet ID of the machine. Conflicts with `subnet_name` (string)
 * `subnet_name` - (Required++) OpenTelekomCloud subnet name of the machine. Conflicts with `subnet_id` (string)
 * `token` - (Optional/Sensitive) OpenTelekomCloud authentication token (string)
-* `tags` - (Optional) OpenTelekomCloud tags (e.g. key1,value1,key2,value2) (string)
+* `tags` - (Optional) OpenTelekomCloud tags (e.g. key1.value1,key2.value2,key3) (string)
 * `user_data_file` - (Optional) File containing an OpenTelekomCloud userdata script (string)
 * `user_data_raw` - (Optional) Contents of the OpenTelekomCloud userdata as a string (string)
 * `username` - (Optional) OpenTelekomCloud username (string)

--- a/rancher2/resource_rancher2_machine_config_v2.go
+++ b/rancher2/resource_rancher2_machine_config_v2.go
@@ -223,6 +223,13 @@ func createMachineConfigV2(c *Config, obj *MachineConfigV2) (*MachineConfigV2, e
 		out.ID = resp.ID
 		out.TypeMeta = resp.TypeMeta
 		out.ObjectMeta = resp.ObjectMeta
+	case machineConfigV2OpentelekomcloudKind:
+		resp := &MachineConfigV2Opentelekomcloud{}
+		err = c.createObjectV2(rancher2DefaultLocalClusterID, machineConfigV2OpentelekomcloudAPIType, obj.OpentelekomcloudConfig, resp)
+		out.OpentelekomcloudConfig = resp
+		out.ID = resp.ID
+		out.TypeMeta = resp.TypeMeta
+		out.ObjectMeta = resp.ObjectMeta
 	case machineConfigV2VmwarevsphereKind:
 		resp := &MachineConfigV2Vmwarevsphere{}
 		err = c.createObjectV2(rancher2DefaultLocalClusterID, machineConfigV2VmwarevsphereAPIType, obj.VmwarevsphereConfig, resp)
@@ -325,6 +332,16 @@ func getMachineConfigV2ByID(c *Config, id, kind string) (*MachineConfigV2, error
 		out.Type = resp.Type
 		out.TypeMeta = resp.TypeMeta
 		out.ObjectMeta = resp.ObjectMeta
+	case machineConfigV2OpentelekomcloudKind:
+		resp := &MachineConfigV2Opentelekomcloud{}
+		err = c.getObjectV2ByID(rancher2DefaultLocalClusterID, id, machineConfigV2OpentelekomcloudAPIType, resp)
+		out.OpentelekomcloudConfig = resp
+		out.ID = resp.ID
+		out.Links = resp.Links
+		out.Actions = resp.Actions
+		out.Type = resp.Type
+		out.TypeMeta = resp.TypeMeta
+		out.ObjectMeta = resp.ObjectMeta
 	case machineConfigV2VmwarevsphereKind:
 		resp := &MachineConfigV2Vmwarevsphere{}
 		err = c.getObjectV2ByID(rancher2DefaultLocalClusterID, id, machineConfigV2VmwarevsphereAPIType, resp)
@@ -397,6 +414,13 @@ func updateMachineConfigV2(c *Config, obj *MachineConfigV2) (*MachineConfigV2, e
 		resp := &MachineConfigV2Openstack{}
 		err = c.updateObjectV2(rancher2DefaultLocalClusterID, obj.ID, machineConfigV2OpenstackAPIType, obj.OpenstackConfig, resp)
 		out.OpenstackConfig = resp
+		out.ID = resp.ID
+		out.TypeMeta = resp.TypeMeta
+		out.ObjectMeta = resp.ObjectMeta
+	case machineConfigV2OpentelekomcloudKind:
+		resp := &MachineConfigV2Opentelekomcloud{}
+		err = c.updateObjectV2(rancher2DefaultLocalClusterID, obj.ID, machineConfigV2OpentelekomcloudAPIType, obj.OpentelekomcloudConfig, resp)
+		out.OpentelekomcloudConfig = resp
 		out.ID = resp.ID
 		out.TypeMeta = resp.TypeMeta
 		out.ObjectMeta = resp.ObjectMeta

--- a/rancher2/resource_rancher2_machine_config_v2_test.go
+++ b/rancher2/resource_rancher2_machine_config_v2_test.go
@@ -1,0 +1,138 @@
+package rancher2
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+const (
+	testAccRancher2MachineConfigV2 = "rancher2_machine_config_v2"
+)
+
+var (
+	testAccRancher2MachineConfigV2Basic  string
+	testAccRancher2MachineConfigV2Update string
+)
+
+func init() {
+	testAccRancher2MachineConfigV2Basic = `
+resource "` + testAccRancher2MachineConfigV2 + `" "foo" {
+  generate_name = "test-foo"
+  opentelekomcloud_config {
+    auth_url          = "https://iam.eu-de.otc.t-systems.com/v3"
+    availability_zone = "eu-de-01"
+    username          = "test-user"
+    password          = "dummy-password"
+    region            = "eu-de"
+    project_name      = "eu-de"
+    domain_name       = "OTC-EU-DE-00000000001-TEST-DOMAIN"
+    flavor_name       = "s3.medium.1"
+    subnet_name       = "subnet-test"
+    vpc_name          = "vpc-test"
+    tags              = "key1.value1,key2.value2,key3"
+    security_groups   = ["default", "sg-test"]
+  }
+}`
+	testAccRancher2MachineConfigV2Update = `
+resource "` + testAccRancher2MachineConfigV2 + `" "foo" {
+  generate_name = "test-foo"
+  opentelekomcloud_config {
+    auth_url          = "https://iam.eu-de.otc.t-systems.com/v3"
+    availability_zone = "eu-de-01"
+    username          = "test-user"
+    password          = "dummy-password-2"
+    region            = "eu-nl"
+    project_name      = "eu-de_main"
+    domain_name       = "OTC-EU-DE-00000000001-TEST-DOMAIN"
+    flavor_name       = "s3x.2.medium.1"
+    subnet_name       = "subnet-prod"
+    vpc_name          = "vpc-test"
+    security_groups   = ["default"]
+  }
+}`
+}
+
+func TestAccRancher2MachineConfigV2Basic(t *testing.T) {
+	rsName := testAccRancher2MachineConfigV2 + ".foo"
+	var machineConfig *MachineConfigV2Opentelekomcloud
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2MachineConfigV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRancher2MachineConfigV2Basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2MachineConfigV2Exists(rsName, machineConfig),
+					resource.TestCheckResourceAttrSet(rsName, "name"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.region", "eu-de"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.project_name", "eu-de"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.flavor_name", "s3.medium.1"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.subnet_name", "subnet-test"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.security_groups.1", "sg-test"),
+				),
+			},
+			{
+				Config: testAccRancher2MachineConfigV2Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2MachineConfigV2Exists(rsName, machineConfig),
+					resource.TestCheckResourceAttrSet(rsName, "name"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.region", "eu-nl"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.project_name", "eu-de_main"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.flavor_name", "s3x.2.medium.1"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.subnet_name", "subnet-prod"),
+					resource.TestCheckResourceAttr(rsName, "opentelekomcloud_config.0.security_groups.0", "default"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRancher2MachineConfigV2Exists(n string, machineConfig *MachineConfigV2Opentelekomcloud) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Machine Config ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config)
+
+		machineConfig = &MachineConfigV2Opentelekomcloud{}
+
+		err := client.getObjectV2ByID("local", rs.Primary.ID, machineConfigV2OpentelekomcloudAPIType, machineConfig)
+		if err != nil {
+			if IsNotFound(err) {
+				return fmt.Errorf("Machine Config V2 not found")
+			}
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRancher2MachineConfigV2Destroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2MachineConfigV2 {
+			continue
+		}
+		client, _ := testAccProvider.Meta().(*Config)
+
+		resp := &MachineConfigV2Opentelekomcloud{}
+
+		err := client.getObjectV2ByID("local", rs.Primary.ID, machineConfigV2OpentelekomcloudAPIType, resp)
+		if err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("Machine Config V2 still exists")
+	}
+	return nil
+}

--- a/rancher2/schema_machine_config_v2.go
+++ b/rancher2/schema_machine_config_v2.go
@@ -11,6 +11,7 @@ var allMachineDriverConfigFields = []string{
 	"harvester_config",
 	"linode_config",
 	"openstack_config",
+	"opentelekomcloud_config",
 	"vsphere_config",
 }
 
@@ -90,6 +91,15 @@ func machineConfigV2Fields() map[string]*schema.Schema {
 			ConflictsWith: getConflicts(allMachineDriverConfigFields, "openstack_config"),
 			Elem: &schema.Resource{
 				Schema: machineConfigV2OpenstackFields(),
+			},
+		},
+		"opentelekomcloud_config": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: getConflicts(allMachineDriverConfigFields, "opentelekomcloud_config"),
+			Elem: &schema.Resource{
+				Schema: machineConfigV2OpentelekomcloudFields(),
 			},
 		},
 		"vsphere_config": {

--- a/rancher2/schema_machine_config_v2_opentelekomcloud.go
+++ b/rancher2/schema_machine_config_v2_opentelekomcloud.go
@@ -148,8 +148,6 @@ func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
 		},
 		"region": {
 			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
 			Required:    true,
 			Description: "Region name",
 		},

--- a/rancher2/schema_machine_config_v2_opentelekomcloud.go
+++ b/rancher2/schema_machine_config_v2_opentelekomcloud.go
@@ -1,0 +1,275 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+//Schemas
+
+func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"access_key": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Sensitive:   true,
+			Description: "Access key used for AK/SK auth ",
+		},
+		"secret_key": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Sensitive:   true,
+			Description: "Access key used for AK/SK auth ",
+		},
+		"auth_url": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Authentication URL",
+		},
+		"availability_zone": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "eu-de-01",
+			Description: "OpenTelekomCloud Availability zone",
+		},
+		"ca_cert": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "CA certificate bundle to verify against",
+		},
+		"domain_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "OpenTelekomCloud Domain ID",
+		},
+		"domain_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "OpenTelekomCloud Domain Name",
+		},
+		"eip": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Elastic IP to use",
+		},
+		"eip_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "5_bgp",
+			Description: "Elastic ip type (either `5_bgp` or `5_mailbgp`)",
+		},
+		"endpoint_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "public",
+			Description: "Endpoint type",
+		},
+		"flavor_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Flavor id to use for the instance",
+		},
+		"flavor_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "s3.xlarge.2",
+			Description: "Flavor name to use for the instance",
+		},
+		"bandwidth_size": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "100",
+			Description: "Bandwidth size",
+		},
+		"bandwidth_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "PER",
+			Description: "Bandwidth share type",
+		},
+		"image_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Image ID to use for the instance",
+		},
+		"image_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "Standard_Ubuntu_20.04_latest",
+			Description: "Image name to use for the instance",
+		},
+		"ip_version": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     4,
+			Description: "Version of IP address assigned for the machine (only 4 is supported by OTC for now)",
+		},
+		"keypair_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Key pair to use to SSH to the instance",
+		},
+		"password": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Computed:    true,
+			Description: "OpenTelekomCloud Password",
+		},
+		"private_key_file": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Private key file to use for SSH (absolute path)",
+		},
+		"project_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.project_id",
+				"opentelekomcloud_config.0.project_name"},
+			Description: "OpenTelekomCloud Project ID",
+		},
+		"project_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.project_id",
+				"opentelekomcloud_config.0.project_name"},
+			Description: "OpenTelekomCloud Project name",
+		},
+		"region": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Required:    true,
+			Description: "Region name",
+		},
+		"root_volume_size": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     40,
+			Description: "Set volume size of root partition (in GB)",
+		},
+		"root_volume_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "SSD",
+			Description: "Set volume type of root partition (one of `SATA`, `SAS`, `SSD`)",
+		},
+		"security_groups": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Computed:    true,
+			Description: "A list of security groups to use",
+		},
+		"server_group": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Define server group where server will be created",
+		},
+		"server_group_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Define server group where server will be created by ID",
+		},
+		"skip_default_sg": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "Parameter to skip default security group creation",
+		},
+		"skip_eip": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "If set machine IP will be set to instance local IP instead of elastic IP",
+		},
+		"ssh_port": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "22",
+			Description: "Machine SSH port",
+		},
+		"ssh_user": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "ubuntu",
+			Description: "SSH user",
+		},
+		"subnet_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.subnet_id",
+				"opentelekomcloud_config.0.subnet_name"},
+			Description: "Subnet ID of the machine",
+		},
+		"subnet_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.subnet_id",
+				"opentelekomcloud_config.0.subnet_name"},
+			Description: "Subnet name of the machine",
+		},
+		"token": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "Authorization token that can be used instead of AK/SK or user/password auth",
+		},
+		"tags": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "OTC Tags (e.g. key1,value1,key2,value2)",
+		},
+		"user_data_file": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "File containing an userdata script",
+		},
+		"user_data_raw": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Contents of user data file as a string",
+		},
+		"username": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "OpenTelekomCloud username ",
+		},
+		"vpc_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.vpc_id",
+				"opentelekomcloud_config.0.vpc_name"},
+			Description: "VPC ID of the machine",
+		},
+		"vpc_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.vpc_id",
+				"opentelekomcloud_config.0.vpc_name"},
+			Description: "VPC Name of the machine",
+		},
+	}
+	return s
+}

--- a/rancher2/schema_machine_config_v2_opentelekomcloud.go
+++ b/rancher2/schema_machine_config_v2_opentelekomcloud.go
@@ -29,7 +29,6 @@ func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
 		},
 		"availability_zone": {
 			Type:        schema.TypeString,
-			Optional:    true,
 			Required:    true,
 			Description: "OpenTelekomCloud Availability zone",
 		},

--- a/rancher2/schema_machine_config_v2_opentelekomcloud.go
+++ b/rancher2/schema_machine_config_v2_opentelekomcloud.go
@@ -30,7 +30,7 @@ func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
 		"availability_zone": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "eu-de-01",
+			Required:    true,
 			Description: "OpenTelekomCloud Availability zone",
 		},
 		"ca_cert": {
@@ -40,15 +40,19 @@ func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
 			Description: "CA certificate bundle to verify against",
 		},
 		"domain_id": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.domain_id",
+				"opentelekomcloud_config.0.domain_name"},
 			Description: "OpenTelekomCloud Domain ID",
 		},
 		"domain_name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ExactlyOneOf: []string{"opentelekomcloud_config.0.domain_id",
+				"opentelekomcloud_config.0.domain_name"},
 			Description: "OpenTelekomCloud Domain Name",
 		},
 		"eip": {

--- a/rancher2/schema_machine_config_v2_opentelekomcloud.go
+++ b/rancher2/schema_machine_config_v2_opentelekomcloud.go
@@ -13,14 +13,14 @@ func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 			Sensitive:   true,
-			Description: "Access key used for AK/SK auth ",
+			Description: "Access key used for AK/SK auth",
 		},
 		"secret_key": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
 			Sensitive:   true,
-			Description: "Access key used for AK/SK auth ",
+			Description: "Access key used for AK/SK auth",
 		},
 		"auth_url": {
 			Type:        schema.TypeString,
@@ -237,7 +237,7 @@ func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
-			Description: "OTC Tags (e.g. key1,value1,key2,value2)",
+			Description: "OTC Tags (e.g. key1.value1,key2.value2,key3)",
 		},
 		"user_data_file": {
 			Type:        schema.TypeString,
@@ -253,7 +253,7 @@ func machineConfigV2OpentelekomcloudFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
-			Description: "OpenTelekomCloud username ",
+			Description: "OpenTelekomCloud username",
 		},
 		"vpc_id": {
 			Type:     schema.TypeString,

--- a/rancher2/structure_machine_config_v2.go
+++ b/rancher2/structure_machine_config_v2.go
@@ -17,15 +17,16 @@ const (
 //Types
 
 type machineConfigV2 struct {
-	metav1.TypeMeta     `json:",inline"`
-	metav1.ObjectMeta   `json:"metadata,omitempty"`
-	Amazonec2Config     *MachineConfigV2Amazonec2     `json:"amazonec2Config,omitempty" yaml:"amazonec2Config,omitempty"`
-	AzureConfig         *MachineConfigV2Azure         `json:"azureConfig,omitempty" yaml:"azureConfig,omitempty"`
-	DigitaloceanConfig  *MachineConfigV2Digitalocean  `json:"digitaloceanConfig,omitempty" yaml:"digitaloceanConfig,omitempty"`
-	HarvesterConfig     *MachineConfigV2Harvester     `json:"harvesterConfig,omitempty" yaml:"harvesterConfig,omitempty"`
-	LinodeConfig        *MachineConfigV2Linode        `json:"linodeConfig,omitempty" yaml:"linodeConfig,omitempty"`
-	OpenstackConfig     *MachineConfigV2Openstack     `json:"openstackConfig,omitempty" yaml:"openstackConfig,omitempty"`
-	VmwarevsphereConfig *MachineConfigV2Vmwarevsphere `json:"vmwarevsphereConfig,omitempty" yaml:"vmwarevsphereConfig,omitempty"`
+	metav1.TypeMeta        `json:",inline"`
+	metav1.ObjectMeta      `json:"metadata,omitempty"`
+	Amazonec2Config        *MachineConfigV2Amazonec2        `json:"amazonec2Config,omitempty" yaml:"amazonec2Config,omitempty"`
+	AzureConfig            *MachineConfigV2Azure            `json:"azureConfig,omitempty" yaml:"azureConfig,omitempty"`
+	DigitaloceanConfig     *MachineConfigV2Digitalocean     `json:"digitaloceanConfig,omitempty" yaml:"digitaloceanConfig,omitempty"`
+	HarvesterConfig        *MachineConfigV2Harvester        `json:"harvesterConfig,omitempty" yaml:"harvesterConfig,omitempty"`
+	LinodeConfig           *MachineConfigV2Linode           `json:"linodeConfig,omitempty" yaml:"linodeConfig,omitempty"`
+	OpenstackConfig        *MachineConfigV2Openstack        `json:"openstackConfig,omitempty" yaml:"openstackConfig,omitempty"`
+	OpentelekomcloudConfig *MachineConfigV2Opentelekomcloud `json:"opentelekomcloudConfig,omitempty" yaml:"opentelekomcloudConfig,omitempty"`
+	VmwarevsphereConfig    *MachineConfigV2Vmwarevsphere    `json:"vmwarevsphereConfig,omitempty" yaml:"vmwarevsphereConfig,omitempty"`
 }
 
 type MachineConfigV2 struct {
@@ -69,6 +70,11 @@ func flattenMachineConfigV2(d *schema.ResourceData, in *MachineConfigV2) error {
 		}
 	case machineConfigV2OpenstackKind:
 		err := d.Set("openstack_config", flattenMachineConfigV2Openstack(in.OpenstackConfig))
+		if err != nil {
+			return err
+		}
+	case machineConfigV2OpentelekomcloudKind:
+		err := d.Set("opentelekomcloud_config", flattenMachineConfigV2Opentelekomcloud(in.OpentelekomcloudConfig))
 		if err != nil {
 			return err
 		}
@@ -139,6 +145,9 @@ func expandMachineConfigV2(in *schema.ResourceData) *MachineConfigV2 {
 	}
 	if v, ok := in.Get("openstack_config").([]interface{}); ok && len(v) > 0 {
 		obj.OpenstackConfig = expandMachineConfigV2Openstack(v, obj)
+	}
+	if v, ok := in.Get("opentelekomcloud_config").([]interface{}); ok && len(v) > 0 {
+		obj.OpentelekomcloudConfig = expandMachineConfigV2Opentelekomcloud(v, obj)
 	}
 	if v, ok := in.Get("vsphere_config").([]interface{}); ok && len(v) > 0 {
 		obj.VmwarevsphereConfig = expandMachineConfigV2Vmwarevsphere(v, obj)

--- a/rancher2/structure_machine_config_v2_opentelekomcloud.go
+++ b/rancher2/structure_machine_config_v2_opentelekomcloud.go
@@ -30,9 +30,9 @@ type machineConfigV2Opentelekomcloud struct {
 	FlavorName        string `json:"flavorName,omitempty" yaml:"flavorName,omitempty"`
 	BandwidthSize     string `json:"bandwidthSize,omitempty" yaml:"bandwidthSize,omitempty"`
 	BandwidthType     string `json:"bandwidthType,omitempty" yaml:"bandwidthType,omitempty"`
-	ImageId           string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
+	ImageID           string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
 	ImageName         string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
-	IpVersion         string `json:"ipVersion,omitempty" yaml:"ipVersion,omitempty"`
+	IPVersion         string `json:"ipVersion,omitempty" yaml:"ipVersion,omitempty"`
 	KeypairName       string `json:"keypairName,omitempty" yaml:"keypairName,omitempty"`
 	Password          string `json:"password,omitempty" yaml:"password,omitempty"`
 	PrivateKeyFile    string `json:"privateKeyFile,omitempty" yaml:"privateKeyFile,omitempty"`
@@ -46,8 +46,8 @@ type machineConfigV2Opentelekomcloud struct {
 	ServerGroupID     string `json:"serverGroupID,omitempty" yaml:"serverGroupID,omitempty"`
 	SkipDefaultSg     bool   `json:"skipDefaultSg,omitempty"  yaml:"skipDefaultSg,omitempty"`
 	SkipEip           bool   `json:"skipEip,omitempty"  yaml:"skipEip,omitempty"`
-	SshPort           string `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
-	SshUser           string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	SSHPort           string `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
+	SSHUser           string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
 	SubnetID          string `json:"subnetId,omitempty" yaml:"subnetId,omitempty"`
 	SubnetName        string `json:"subnetName,omitempty" yaml:"subnetName,omitempty"`
 	Token             string `json:"token,omitempty"  yaml:"token,omitempty"`
@@ -87,9 +87,9 @@ func flattenMachineConfigV2Opentelekomcloud(in *MachineConfigV2Opentelekomcloud)
 	obj["flavor_name"] = in.FlavorName
 	obj["bandwidth_size"] = in.BandwidthSize
 	obj["bandwidth_type"] = in.BandwidthType
-	obj["image_id"] = in.ImageId
+	obj["image_id"] = in.ImageID
 	obj["image_name"] = in.ImageName
-	obj["ip_version"] = in.IpVersion
+	obj["ip_version"] = in.IPVersion
 	obj["keypair_name"] = in.KeypairName
 	obj["password"] = in.Password
 	obj["private_key_file"] = in.PrivateKeyFile
@@ -103,8 +103,8 @@ func flattenMachineConfigV2Opentelekomcloud(in *MachineConfigV2Opentelekomcloud)
 	obj["server_group_id"] = in.ServerGroupID
 	obj["skip_default_sg"] = in.SkipDefaultSg
 	obj["skip_eip"] = in.SkipEip
-	obj["ssh_port"] = in.SshPort
-	obj["ssh_user"] = in.SshUser
+	obj["ssh_port"] = in.SSHPort
+	obj["ssh_user"] = in.SSHUser
 	obj["subnet_id"] = in.SubnetID
 	obj["subnet_name"] = in.SubnetName
 	obj["token"] = in.Token
@@ -178,13 +178,13 @@ func expandMachineConfigV2Opentelekomcloud(p []interface{}, source *MachineConfi
 		obj.BandwidthType = v
 	}
 	if v, ok := in["image_id"].(string); ok && len(v) > 0 {
-		obj.ImageId = v
+		obj.ImageID = v
 	}
 	if v, ok := in["image_name"].(string); ok && len(v) > 0 {
 		obj.ImageName = v
 	}
 	if v, ok := in["ip_version"].(string); ok && len(v) > 0 {
-		obj.IpVersion = v
+		obj.IPVersion = v
 	}
 	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
 		obj.KeypairName = v
@@ -226,10 +226,10 @@ func expandMachineConfigV2Opentelekomcloud(p []interface{}, source *MachineConfi
 		obj.SkipEip = v
 	}
 	if v, ok := in["ssh_port"].(string); ok && len(v) > 0 {
-		obj.SshPort = v
+		obj.SSHPort = v
 	}
 	if v, ok := in["ssh_user"].(string); ok && len(v) > 0 {
-		obj.SshUser = v
+		obj.SSHUser = v
 	}
 	if v, ok := in["subnet_id"].(string); ok && len(v) > 0 {
 		obj.SubnetID = v

--- a/rancher2/structure_machine_config_v2_opentelekomcloud.go
+++ b/rancher2/structure_machine_config_v2_opentelekomcloud.go
@@ -1,0 +1,262 @@
+package rancher2
+
+import (
+	norman "github.com/rancher/norman/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	machineConfigV2OpentelekomcloudKind       = "OtcConfig"
+	machineConfigV2OpentelekomcloudAPIVersion = "rke-machine-config.cattle.io/v1"
+	machineConfigV2OpentelekomcloudAPIType    = "rke-machine-config.cattle.io.otcconfig"
+)
+
+//Types
+
+type machineConfigV2Opentelekomcloud struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	AccessKey         string `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
+	SecretKey         string `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
+	AuthURL           string `json:"authUrl,omitempty" yaml:"authUrl,omitempty"`
+	AvailabilityZone  string `json:"availabilityZone,omitempty" yaml:"availabilityZone,omitempty"`
+	CaCert            string `json:"cacert,omitempty" yaml:"cacert,omitempty"`
+	DomainID          string `json:"domainId,omitempty" yaml:"domainId,omitempty"`
+	DomainName        string `json:"domainName,omitempty" yaml:"domainName,omitempty"`
+	Eip               string `json:"eip,omitempty" yaml:"eip,omitempty"`
+	EipType           string `json:"eipType,omitempty" yaml:"eipType,omitempty"`
+	EndpointType      string `json:"endpointType,omitempty" yaml:"endpointType,omitempty"`
+	FlavorID          string `json:"flavorId,omitempty" yaml:"flavorId,omitempty"`
+	FlavorName        string `json:"flavorName,omitempty" yaml:"flavorName,omitempty"`
+	BandwidthSize     string `json:"bandwidthSize,omitempty" yaml:"bandwidthSize,omitempty"`
+	BandwidthType     string `json:"bandwidthType,omitempty" yaml:"bandwidthType,omitempty"`
+	ImageId           string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
+	ImageName         string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	IpVersion         string `json:"ipVersion,omitempty" yaml:"ipVersion,omitempty"`
+	KeypairName       string `json:"keypairName,omitempty" yaml:"keypairName,omitempty"`
+	Password          string `json:"password,omitempty" yaml:"password,omitempty"`
+	PrivateKeyFile    string `json:"privateKeyFile,omitempty" yaml:"privateKeyFile,omitempty"`
+	ProjectID         string `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	ProjectName       string `json:"projectName,omitempty" yaml:"projectName,omitempty"`
+	Region            string `json:"region,omitempty" yaml:"region,omitempty"`
+	RootVolumeSize    string `json:"rootVolumeSize,omitempty" yaml:"rootVolumeSize,omitempty"`
+	RootVolumeType    string `json:"rootVolumeType,omitempty" yaml:"rootVolumeType,omitempty"`
+	SecGroups         string `json:"secGroups,omitempty" yaml:"secGroups,omitempty"`
+	ServerGroup       string `json:"serverGroup,omitempty" yaml:"serverGroup,omitempty"`
+	ServerGroupID     string `json:"serverGroupID,omitempty" yaml:"serverGroupID,omitempty"`
+	SkipDefaultSg     bool   `json:"skipDefaultSg,omitempty"  yaml:"skipDefaultSg,omitempty"`
+	SkipEip           bool   `json:"skipEip,omitempty"  yaml:"skipEip,omitempty"`
+	SshPort           string `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
+	SshUser           string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	SubnetID          string `json:"subnetId,omitempty" yaml:"subnetId,omitempty"`
+	SubnetName        string `json:"subnetName,omitempty" yaml:"subnetName,omitempty"`
+	Token             string `json:"token,omitempty"  yaml:"token,omitempty"`
+	Tags              string `json:"tags,omitempty"  yaml:"tags,omitempty"`
+	UserDataFile      string `json:"userDataFile,omitempty"  yaml:"userDataFile,omitempty"`
+	UserDataRaw       string `json:"userDataRaw,omitempty"  yaml:"userDataRaw,omitempty"`
+	Username          string `json:"username,omitempty" yaml:"username,omitempty"`
+	VpcID             string `json:"vpcId,omitempty" yaml:"vpcId,omitempty"`
+	VpcName           string `json:"vpcName,omitempty" yaml:"vpcName,omitempty"`
+}
+
+type MachineConfigV2Opentelekomcloud struct {
+	norman.Resource
+	machineConfigV2Opentelekomcloud
+}
+
+// Flatteners
+
+func flattenMachineConfigV2Opentelekomcloud(in *MachineConfigV2Opentelekomcloud) []interface{} {
+	if in == nil {
+		return nil
+	}
+
+	obj := make(map[string]interface{})
+
+	obj["access_key"] = in.AccessKey
+	obj["secret_key"] = in.SecretKey
+	obj["auth_url"] = in.AuthURL
+	obj["availability_zone"] = in.AvailabilityZone
+	obj["ca_cert"] = in.CaCert
+	obj["domain_id"] = in.DomainID
+	obj["domain_name"] = in.DomainName
+	obj["eip"] = in.Eip
+	obj["eip_type"] = in.EipType
+	obj["endpoint_type"] = in.EndpointType
+	obj["flavor_id"] = in.FlavorID
+	obj["flavor_name"] = in.FlavorName
+	obj["bandwidth_size"] = in.BandwidthSize
+	obj["bandwidth_type"] = in.BandwidthType
+	obj["image_id"] = in.ImageId
+	obj["image_name"] = in.ImageName
+	obj["ip_version"] = in.IpVersion
+	obj["keypair_name"] = in.KeypairName
+	obj["password"] = in.Password
+	obj["private_key_file"] = in.PrivateKeyFile
+	obj["project_id"] = in.ProjectID
+	obj["project_name"] = in.ProjectName
+	obj["region"] = in.Region
+	obj["root_volume_size"] = in.RootVolumeSize
+	obj["root_volume_type"] = in.RootVolumeType
+	obj["security_groups"] = toArraySplitComma(in.SecGroups)
+	obj["server_group"] = in.ServerGroup
+	obj["server_group_id"] = in.ServerGroupID
+	obj["skip_default_sg"] = in.SkipDefaultSg
+	obj["skip_eip"] = in.SkipEip
+	obj["ssh_port"] = in.SshPort
+	obj["ssh_user"] = in.SshUser
+	obj["subnet_id"] = in.SubnetID
+	obj["subnet_name"] = in.SubnetName
+	obj["token"] = in.Token
+	obj["tags"] = in.Tags
+	obj["user_data_file"] = in.UserDataFile
+	obj["user_data_raw"] = in.UserDataRaw
+	obj["username"] = in.Username
+	obj["vpc_id"] = in.VpcID
+	obj["vpc_name"] = in.VpcName
+	return []interface{}{obj}
+}
+
+// Expanders
+
+func expandMachineConfigV2Opentelekomcloud(p []interface{}, source *MachineConfigV2) *MachineConfigV2Opentelekomcloud {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+	obj := &MachineConfigV2Opentelekomcloud{}
+
+	if len(source.ID) > 0 {
+		obj.ID = source.ID
+	}
+	in := p[0].(map[string]interface{})
+
+	obj.TypeMeta.Kind = machineConfigV2OpentelekomcloudKind
+	obj.TypeMeta.APIVersion = machineConfigV2OpentelekomcloudAPIVersion
+	source.TypeMeta = obj.TypeMeta
+	obj.ObjectMeta = source.ObjectMeta
+
+	if v, ok := in["access_key"].(string); ok && len(v) > 0 {
+		obj.AccessKey = v
+	}
+	if v, ok := in["secret_key"].(string); ok && len(v) > 0 {
+		obj.SecretKey = v
+	}
+	if v, ok := in["auth_url"].(string); ok && len(v) > 0 {
+		obj.AuthURL = v
+	}
+	if v, ok := in["availability_zone"].(string); ok && len(v) > 0 {
+		obj.AvailabilityZone = v
+	}
+	if v, ok := in["cacert"].(string); ok && len(v) > 0 {
+		obj.CaCert = v
+	}
+	if v, ok := in["domain_id"].(string); ok && len(v) > 0 {
+		obj.DomainID = v
+	}
+	if v, ok := in["domain_name"].(string); ok && len(v) > 0 {
+		obj.DomainName = v
+	}
+	if v, ok := in["eip"].(string); ok && len(v) > 0 {
+		obj.Eip = v
+	}
+	if v, ok := in["eip_type"].(string); ok && len(v) > 0 {
+		obj.EipType = v
+	}
+	if v, ok := in["endpoint_type"].(string); ok && len(v) > 0 {
+		obj.EndpointType = v
+	}
+	if v, ok := in["flavor_id"].(string); ok && len(v) > 0 {
+		obj.FlavorID = v
+	}
+	if v, ok := in["flavor_name"].(string); ok && len(v) > 0 {
+		obj.FlavorName = v
+	}
+	if v, ok := in["bandwidth_size"].(string); ok && len(v) > 0 {
+		obj.BandwidthSize = v
+	}
+	if v, ok := in["bandwidth_type"].(string); ok && len(v) > 0 {
+		obj.BandwidthType = v
+	}
+	if v, ok := in["image_id"].(string); ok && len(v) > 0 {
+		obj.ImageId = v
+	}
+	if v, ok := in["image_name"].(string); ok && len(v) > 0 {
+		obj.ImageName = v
+	}
+	if v, ok := in["ip_version"].(string); ok && len(v) > 0 {
+		obj.IpVersion = v
+	}
+	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
+		obj.KeypairName = v
+	}
+	if v, ok := in["password"].(string); ok && len(v) > 0 {
+		obj.Password = v
+	}
+	if v, ok := in["private_key_file"].(string); ok && len(v) > 0 {
+		obj.PrivateKeyFile = v
+	}
+	if v, ok := in["project_Id"].(string); ok && len(v) > 0 {
+		obj.ProjectID = v
+	}
+	if v, ok := in["project_name"].(string); ok && len(v) > 0 {
+		obj.ProjectName = v
+	}
+	if v, ok := in["region"].(string); ok && len(v) > 0 {
+		obj.Region = v
+	}
+	if v, ok := in["root_volume_size"].(string); ok && len(v) > 0 {
+		obj.RootVolumeSize = v
+	}
+	if v, ok := in["root_volume_type"].(string); ok && len(v) > 0 {
+		obj.RootVolumeType = v
+	}
+	if v, ok := in["security_groups"].([]interface{}); ok && len(v) > 0 {
+		obj.SecGroups = toArrayJoinComma(v)
+	}
+	if v, ok := in["server_group"].(string); ok && len(v) > 0 {
+		obj.ServerGroup = v
+	}
+	if v, ok := in["server_group_id"].(string); ok && len(v) > 0 {
+		obj.ServerGroupID = v
+	}
+	if v, ok := in["skip_default_sg"].(bool); ok {
+		obj.SkipDefaultSg = v
+	}
+	if v, ok := in["skip_eip"].(bool); ok {
+		obj.SkipEip = v
+	}
+	if v, ok := in["ssh_port"].(string); ok && len(v) > 0 {
+		obj.SshPort = v
+	}
+	if v, ok := in["ssh_user"].(string); ok && len(v) > 0 {
+		obj.SshUser = v
+	}
+	if v, ok := in["subnet_id"].(string); ok && len(v) > 0 {
+		obj.SubnetID = v
+	}
+	if v, ok := in["subnet_name"].(string); ok && len(v) > 0 {
+		obj.SubnetName = v
+	}
+	if v, ok := in["token"].(string); ok && len(v) > 0 {
+		obj.Token = v
+	}
+	if v, ok := in["tags"].(string); ok && len(v) > 0 {
+		obj.Tags = v
+	}
+	if v, ok := in["user_data_file"].(string); ok && len(v) > 0 {
+		obj.UserDataFile = v
+	}
+	if v, ok := in["user_data_raw"].(string); ok && len(v) > 0 {
+		obj.UserDataRaw = v
+	}
+	if v, ok := in["username"].(string); ok && len(v) > 0 {
+		obj.Username = v
+	}
+	if v, ok := in["vpc_id"].(string); ok && len(v) > 0 {
+		obj.VpcID = v
+	}
+	if v, ok := in["vpc_name"].(string); ok && len(v) > 0 {
+		obj.VpcName = v
+	}
+	return obj
+}

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -518,6 +518,19 @@ func toArrayInterfaceSorted(in []string) []interface{} {
 	return out
 }
 
+func toArraySplitComma(in string) []string {
+	return strings.Split(in, ",")
+}
+
+func toArrayJoinComma(slice []interface{}) string {
+	strSlice := make([]string, 0, len(slice))
+	for _, elem := range slice {
+		str, _ := elem.(string)
+		strSlice = append(strSlice, str)
+	}
+	return strings.Join(strSlice, ",")
+}
+
 func toMapString(in map[string]interface{}) map[string]string {
 	out := make(map[string]string)
 	for i, v := range in {


### PR DESCRIPTION
## Summary of the Pull Request
Added support for OpenTelekomCloud for `rancher2_machine_config_v2` resource.

## PR Checklist

* [x] Refers to: #3
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance tests setup
Following minimal env vars are needed to run tests:
```
RANCHER_INSECURE=false;
RANCHER_TOKEN_KEY=token-XXXXXXXXXX;
RANCHER_URL=https://rancher-test.XXXXXX.in;
TF_ACC=1
```

## Acceptance Steps Performed
2024/04/02 14:42:11 Getting from  https://rancher-test.XXXXXXXin/ping
2024/04/02 14:42:11 Time to get req:  219  ms
=== RUN   TestAccRancher2MachineConfigV2Basic
--- PASS: TestAccRancher2MachineConfigV2Basic (7.68s)
PASS

Process finished with the exit code 0